### PR TITLE
fix: update Doctor Dashboard heading to proper title case

### DIFF
--- a/views/Doctor/docDashboard.ejs
+++ b/views/Doctor/docDashboard.ejs
@@ -34,7 +34,7 @@
                 <br />
                 <div class="d-flex flex-row">
                     <div class="page-heading">
-                        <h3>DOCTOR DASHBOARD</h3>
+                        <h3>Doctor Dashboard</h3>
                     </div>
                 </div>
 


### PR DESCRIPTION
Fixes heading showing weird text (issue #20). Changed from all-caps 'DOCTOR DASHBOARD' to properly formatted 'Doctor Dashboard'.