### PR TITLE
fix: Remove weird text from Doctor Dashboard heading

### DIFF
--- a/views/Doctor/docDashboard.ejs
+++ b/views/Doctor/docDashboard.ejs
@@ -51,7 +51,7 @@
                 <br />
                 <div class="d-flex flex-row">
                     <div class="page-heading">
-                        <h3>DOCTOR DASHBOARD test</h3>
+                        <h3>DOCTOR DASHBOARD</h3>
                     </div>
                 </div>
 


### PR DESCRIPTION
Fixes #24

Removed the stray "test" text from the Doctor Dashboard title heading in `views/Doctor/docDashboard.ejs`.

Generated with [Claude Code](https://claude.ai/code)